### PR TITLE
Fix EnableIf / DisableIf macro

### DIFF
--- a/src/common/typeutils.h
+++ b/src/common/typeutils.h
@@ -20,11 +20,11 @@ template <class T> using ReturnType = typename ReturnType_<T>::type;
 template <class T> using FirstArgument = typename FirstArgument_<T>::type;
 template <class T> using RemovePointer = typename std::remove_pointer<T>::type;
 
-#define EnableImpl(...) typename std::enable_if_t<__VA_ARGS__> *
-#define DisableImpl(...) typename std::enable_if_t<!(__VA_ARGS__)> *
+#define EnableImpl(...) bool B, typename std::enable_if_t<B && (__VA_ARGS__), int>
+#define DisableImpl(...) bool B, typename std::enable_if_t<!B && !(__VA_ARGS__), int>
 
-#define EnableIf(...) EnableImpl(__VA_ARGS__) = nullptr
-#define DisableIf(...) DisableImpl(__VA_ARGS__) = nullptr
+#define EnableIf(...) bool B = (__VA_ARGS__), typename std::enable_if_t<B && (__VA_ARGS__), int> = 0
+#define DisableIf(...) bool B = (__VA_ARGS__), typename std::enable_if_t<!B && !(__VA_ARGS__), int> = 0
 
 #define IsEnum(T) std::is_enum<T>::value
 #define Convertible(T1, T2) std::is_convertible<T1, T2>::value


### PR DESCRIPTION
This fixes two things:

You cannot have a std::enable_if on a member function which is only
conditional on the template parameters of the class it belongs to. The
typical way to solve this is by doing redeclaring the type in the function
template, eg:
```
template<typename T>
class Foo {
template<typename U = T, std::enable_if<is_something<U>> void bar();
}
```

However that would require usage of the macro to look like:
```
template<typename U = T, EnableIf(is_something<U>)>
```

So instead we can make your macro add a bool type to the template paramater
list which is the result of the enable_if, and then use std::enable_if on
that instead, eg:
```
bool B = (__VA_ARGS__), typename std::enable_if_t<B, int> = 0
```

However there is one more problem, as you overload your functions with this
macro (eg Matrix::determinant), this leads to both overloads having the
same type signature `template<bool B, typename std::enable_if_t<B, int>>` so
you end up with duplicated function error.

The way to fix that is to ensure both functions have separate type
signatures, to do that we can repeat the `__VA_ARGS__` condition inside the
std::enable_if usage - whilst still being sure to use B to satisfy the
previously mentioned constraint. Which finally leads us to:
```
bool B = (__VA_ARGS__), typename std::enable_if_t<!B && !(__VA_ARGS__), int> = 0
```

Also this is on top of pr #4 