### PR TITLE
Fix static_assert without message.

### DIFF
--- a/src/armjit.cpp
+++ b/src/armjit.cpp
@@ -12,7 +12,7 @@
 
 
 static const int CPSR = offsetof(ARMProcessor, core.cpsr);
-static_assert(CPSR < 0x80);
+static_assert(CPSR < 0x80, "offsetof core.cpsr < 0x80");
 
 #define REG(i) offsetof(ARMProcessor, core.regs[ARMCore::i])
 #define GPR(exp) offsetof(ARMProcessor, core.regs) + 4 * (exp)

--- a/src/armthumbjit.cpp
+++ b/src/armthumbjit.cpp
@@ -12,7 +12,7 @@
 
 
 static const int CPSR = offsetof(ARMProcessor, core.cpsr);
-static_assert(CPSR < 0x80);
+static_assert(CPSR < 0x80, "offsetof core.cpsr < 0x80");
 
 #define REG(i) offsetof(ARMProcessor, core.regs[ARMCore::i])
 #define GPR(exp) offsetof(ARMProcessor, core.regs) + 4 * (exp)

--- a/src/ppcjit.cpp
+++ b/src/ppcjit.cpp
@@ -13,7 +13,7 @@
 
 static const int PC = offsetof(PPCProcessor, core.pc);
 static const int CR = offsetof(PPCProcessor, core.cr);
-static_assert(CR < 0x80);
+static_assert(CR < 0x80, "offsetof core.cr < 0x80");
 
 #define REG(i) (offsetof(PPCProcessor, core.regs) + (i) * 4)
 #define SPR(r) (offsetof(PPCProcessor, core.sprs[PPCCore::r]))


### PR DESCRIPTION
You are targeting C++14 where a message for static_assert is required, the message only becomes optional in C++17.