### PR TITLE
CI: Speedup the build step by using make’s parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
 
     - name: Build
       run: |
-        make
+        make -j$(nproc)


### PR DESCRIPTION
Using this option, the CI will now build the .o files in parallel on its multiple cores, making the build step go from 1:40 down to 1:04 in one run.