### PR TITLE
Support 8gb MLC dumps

### DIFF
--- a/src/hardware/sdio.cpp
+++ b/src/hardware/sdio.cpp
@@ -10,30 +10,30 @@
 #include <fcntl.h>
 
 SDIOCard::SDIOCard() : csd() {
-	csd.csdStructure = 1; // version 2
+	csd.csd_structure = 1; // version 2
 	csd.taac = 0xE; // 1 ms
 	csd.nsac = 0;
-	csd.tranSpeed = 0x32; // 25 Mbit/s
+	csd.tran_speed = 0x32; // 25 Mbit/s
 	csd.ccc = 0x5B5;
-	csd.readBlLen = 0x9; // 512 bytes
-	csd.readBlPartial = 0;
-	csd.writeBlkMisalign = 0;
-	csd.readBlkMisalign = 0;
-	csd.dsrImp = 0;
-	csd.cSize_hi = 0;
-	csd.cSize_lo = 0;
-	csd.eraseBlkEnable = 0x1;
-	csd.sectorSize = 0x7F; // 128 blocks
-	csd.wpGrpSize = 0;
-	csd.wpGrpEnable = 0;
-	csd.r2wFactor = 0x2; // x4
-	csd.writeBlLen = 0x9; // 512 bytes
-	csd.writeGrpEnable = 0;
-	csd.fileFormatGrp = 0;
+	csd.read_bl_len = 0x9; // 512 bytes
+	csd.read_bl_partial = 0;
+	csd.write_blk_misalign = 0;
+	csd.read_blk_misalign = 0;
+	csd.dsr_imp = 0;
+	csd.csize_hi = 0;
+	csd.csize_lo = 0;
+	csd.erase_blk_enable = 0x1;
+	csd.sector_size = 0x7F; // 128 blocks
+	csd.wp_grp_size = 0;
+	csd.wp_grp_enable = 0;
+	csd.r2w_factor = 0x2; // x4
+	csd.write_bl_len = 0x9; // 512 bytes
+	csd.write_grp_enable = 0;
+	csd.file_format_grp = 0;
 	csd.copy = 0;
-	csd.permWriteProtect = 0;
-	csd.twpWriteProtect = 0;
-	csd.fileFormat = 0;
+	csd.perm_write_protect = 0;
+	csd.twp_write_protect = 0;
+	csd.file_format = 0;
 	csd.crc = 0x01;
 }
 
@@ -48,15 +48,15 @@ MLCCard::MLCCard() {
 	loff_t size = ftello64(f);
 	fclose(f);
 
-	is32gb = size >= 0x1DB800000;
+	is_32gb = size >= 0x1DB800000;
 
-	csd.cSize_lo = is32gb ? 0xFFFF : 0x3FFF;
+	csd.csize_lo = is_32gb ? 0xFFFF : 0x3FFF;
 
-	data = memory_mapped_file_open("files/mlc.bin", is32gb ? 0x76E000000 : 0x1DB800000);
+	data = memory_mapped_file_open("files/mlc.bin", is_32gb ? 0x76E000000 : 0x1DB800000);
 }
 
 MLCCard::~MLCCard() {
-	memory_mapped_file_close(data, is32gb ? 0x76E000000 : 0x1DB800000);
+	memory_mapped_file_close(data, is_32gb ? 0x76E000000 : 0x1DB800000);
 }
 
 Buffer MLCCard::read(uint64_t offset, uint32_t size) {

--- a/src/hardware/sdio.h
+++ b/src/hardware/sdio.h
@@ -9,9 +9,51 @@ class PhysicalMemory;
 
 class SDIOCard {
 public:
+	SDIOCard();
 	virtual ~SDIOCard();
 	
 	virtual Buffer read(uint64_t offset, uint32_t size) = 0;
+
+	union CardSpecificData {
+		struct {
+			uint32_t tranSpeed : 8;
+			uint32_t nsac : 8;
+			uint32_t taac : 8;
+			uint32_t reserved0 : 6;
+			uint32_t csdStructure : 2;
+
+			uint32_t cSize_hi : 6;
+			uint32_t reserved1 : 6;
+			uint32_t dsrImp : 1;
+			uint32_t readBlkMisalign : 1;
+			uint32_t writeBlkMisalign : 1;
+			uint32_t readBlPartial : 1;
+			uint32_t readBlLen : 4;
+			uint32_t ccc : 12;
+
+			uint32_t wpGrpSize : 7;
+			uint32_t sectorSize : 7;
+			uint32_t eraseBlkEnable : 1;
+			uint32_t reserved2 : 1;
+			uint32_t cSize_lo : 16;
+
+			uint32_t crc : 8;
+			uint32_t reserved5 : 2;
+			uint32_t fileFormat : 2;
+			uint32_t twpWriteProtect : 1;
+			uint32_t permWriteProtect : 1;
+			uint32_t copy : 1;
+			uint32_t fileFormatGrp : 1;
+			uint32_t reserved4 : 5;
+			uint32_t writeGrpEnable : 1;
+			uint32_t writeBlLen : 4;
+			uint32_t r2wFactor : 3;
+			uint32_t reserved3 : 2;
+			uint32_t wpGrpEnable : 1;
+		} __attribute__((packed));
+		uint32_t data[4];
+	};
+	CardSpecificData csd;
 };
 
 
@@ -23,6 +65,7 @@ public:
 	Buffer read(uint64_t offset, uint32_t size);
 	
 private:
+	bool is32gb;
 	uint8_t *data;
 };
 

--- a/src/hardware/sdio.h
+++ b/src/hardware/sdio.h
@@ -16,40 +16,40 @@ public:
 
 	union CardSpecificData {
 		struct {
-			uint32_t tranSpeed : 8;
+			uint32_t tran_speed : 8;
 			uint32_t nsac : 8;
 			uint32_t taac : 8;
 			uint32_t reserved0 : 6;
-			uint32_t csdStructure : 2;
+			uint32_t csd_structure : 2;
 
-			uint32_t cSize_hi : 6;
+			uint32_t csize_hi : 6;
 			uint32_t reserved1 : 6;
-			uint32_t dsrImp : 1;
-			uint32_t readBlkMisalign : 1;
-			uint32_t writeBlkMisalign : 1;
-			uint32_t readBlPartial : 1;
-			uint32_t readBlLen : 4;
+			uint32_t dsr_imp : 1;
+			uint32_t read_blk_misalign : 1;
+			uint32_t write_blk_misalign : 1;
+			uint32_t read_bl_partial : 1;
+			uint32_t read_bl_len : 4;
 			uint32_t ccc : 12;
 
-			uint32_t wpGrpSize : 7;
-			uint32_t sectorSize : 7;
-			uint32_t eraseBlkEnable : 1;
+			uint32_t wp_grp_size : 7;
+			uint32_t sector_size : 7;
+			uint32_t erase_blk_enable : 1;
 			uint32_t reserved2 : 1;
-			uint32_t cSize_lo : 16;
+			uint32_t csize_lo : 16;
 
 			uint32_t crc : 8;
 			uint32_t reserved5 : 2;
-			uint32_t fileFormat : 2;
-			uint32_t twpWriteProtect : 1;
-			uint32_t permWriteProtect : 1;
+			uint32_t file_format : 2;
+			uint32_t twp_write_protect : 1;
+			uint32_t perm_write_protect : 1;
 			uint32_t copy : 1;
-			uint32_t fileFormatGrp : 1;
+			uint32_t file_format_grp : 1;
 			uint32_t reserved4 : 5;
-			uint32_t writeGrpEnable : 1;
-			uint32_t writeBlLen : 4;
-			uint32_t r2wFactor : 3;
+			uint32_t write_grp_enable : 1;
+			uint32_t write_bl_len : 4;
+			uint32_t r2w_factor : 3;
 			uint32_t reserved3 : 2;
-			uint32_t wpGrpEnable : 1;
+			uint32_t wp_grp_enable : 1;
 		} __attribute__((packed));
 		uint32_t data[4];
 	};
@@ -65,7 +65,7 @@ public:
 	Buffer read(uint64_t offset, uint32_t size);
 	
 private:
-	bool is32gb;
+	bool is_32gb;
 	uint8_t *data;
 };
 


### PR DESCRIPTION
Implements the Card Specific Data as a struct and sets the size field accordingly.
I didn't dump the CSD from a real console, so the card size value might be different on real hardware.
Tested it with my 8 gb MLC dump and it works fine. 