### PR TITLE
Add support for boot0 emulation

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -19,7 +19,7 @@ void signal_handler(int signal) {
 }
 
 
-Emulator::Emulator() :
+Emulator::Emulator(bool boot0) :
 	physmem(&hardware),
 	hardware(this),
 	debugger(this),
@@ -29,17 +29,20 @@ Emulator::Emulator() :
 		{this, &reservation, 1},
 		{this, &reservation, 2}
 	},
-	dsp(this)
+	dsp(this),
+	boot0(boot0)
 {
 	reset();
 }
 
 void Emulator::reset() {
-	Buffer buffer = FileUtils::load("files/boot1.bin");
-	physmem.write(0xD400200, buffer);
-	
+
+	Buffer buffer = FileUtils::load(boot0 ? "files/boot0.bin" : "files/boot1.bin");
+	uint32_t load_address = boot0 ? 0xFFFF0000 : 0xD400200;
+	physmem.write(load_address, buffer);
+
 	arm.reset();
-	arm.core.regs[ARMCore::PC] = 0xD400200;
+	arm.core.regs[ARMCore::PC] = load_address;
 	arm.enable();
 	
 	reservation.reset();

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -14,7 +14,7 @@
 
 class Emulator {
 public:
-	Emulator();
+	Emulator(bool boot0);
 	
 	void run();
 	void pause();
@@ -36,4 +36,5 @@ private:
 	int core;
 	
 	bool running;
+	bool boot0;
 };

--- a/src/hardware/aes.cpp
+++ b/src/hardware/aes.cpp
@@ -55,13 +55,15 @@ void AESController::write(uint32_t addr, uint32_t value) {
 					else {
 						AES_set_encrypt_key((uint8_t *)key, 128, &aeskey);
 					}
+
+					memcpy(aesiv, iv, 16);
 				}
 				
 				if (value & 0x8000000) {
-					AES_cbc_encrypt(data.get(), data.get(), size, &aeskey, (uint8_t *)iv, AES_DECRYPT);
+					AES_cbc_encrypt(data.get(), data.get(), size, &aeskey, aesiv, AES_DECRYPT);
 				}
 				else {
-					AES_cbc_encrypt(data.get(), data.get(), size, &aeskey, (uint8_t *)iv, AES_ENCRYPT);
+					AES_cbc_encrypt(data.get(), data.get(), size, &aeskey, aesiv, AES_ENCRYPT);
 				}
 			}
 			

--- a/src/hardware/aes.h
+++ b/src/hardware/aes.h
@@ -38,6 +38,7 @@ private:
 	uint32_t iv[4];
 	
 	::AES_KEY aeskey;
+	uint8_t aesiv[16];
 	
 	PhysicalMemory *physmem;
 };

--- a/src/hardware/latte.cpp
+++ b/src/hardware/latte.cpp
@@ -60,8 +60,8 @@ void LatteController::reset() {
 	aipprot = 0;
 	aipctrl = 0;
 	di_reset = 0;
-	spare = 0;
-	boot0 = 0;
+	spare0 = 0;
+	spare1 = 0;
 	clock_info = 0;
 	resets_compat = 0;
 	ifpower = 0;
@@ -117,8 +117,8 @@ uint32_t LatteController::read(uint32_t addr) {
 		case LT_AIP_PROT: return aipprot;
 		case LT_AIP_IOCTRL: return aipctrl;
 		case LT_DI_RESET: return di_reset;
-		case LT_SPARE: return spare;
-		case LT_BOOT0: return boot0;
+		case LT_SPARE0: return spare0;
+		case LT_SPARE1: return spare1;
 		case LT_CLOCKINFO: return clock_info;
 		case LT_RESETS_COMPAT: return resets_compat;
 		case LT_IFPOWER: return ifpower;
@@ -182,8 +182,18 @@ void LatteController::write(uint32_t addr, uint32_t value) {
 	else if (addr == LT_AIP_IOCTRL) aipctrl = value;
 	else if (addr == LT_USB_RESET) {}
 	else if (addr == LT_DI_RESET) di_reset = value;
-	else if (addr == LT_SPARE) spare = value;
-	else if (addr == LT_BOOT0) boot0 = value;
+	else if (addr == LT_SPARE0) {
+		spare0 = value;
+
+		// boot0 writes to spare0 and waits for spare1 flags to change
+		if (value & 0x2000000) {
+			spare1 |= 0b1001;
+		}
+		else if (value & 0x10000) {
+			spare1 &= ~0b1001;
+		}
+	}
+	else if (addr == LT_SPARE1) spare1 = value;
 	else if (addr == LT_CLOCKINFO) clock_info = value;
 	else if (addr == LT_RESETS_COMPAT) {
 		uint32_t changed = resets_compat ^ value;

--- a/src/hardware/latte.h
+++ b/src/hardware/latte.h
@@ -59,8 +59,8 @@ public:
 		LT_AIP_IOCTRL = 0xD000074,
 		LT_USB_RESET = 0xD000088,
 		LT_DI_RESET = 0xD000180,
-		LT_SPARE = 0xD000188,
-		LT_BOOT0 = 0xD00018C,
+		LT_SPARE0 = 0xD000188,
+		LT_SPARE1 = 0xD00018C,
 		LT_CLOCKINFO = 0xD000190,
 		LT_RESETS_COMPAT = 0xD000194,
 		LT_IFPOWER = 0xD000198,
@@ -139,8 +139,8 @@ private:
 	uint32_t aipprot;
 	uint32_t aipctrl;
 	uint32_t di_reset;
-	uint32_t spare;
-	uint32_t boot0;
+	uint32_t spare0;
+	uint32_t spare1;
 	uint32_t clock_info;
 	uint32_t resets_compat;
 	uint32_t ifpower;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,12 @@ int main(int argc, const char *argv[]) {
 	Logger::init(Logger::DEBUG);
 	History::init();
 
-	Emulator *emulator = new Emulator();
+	bool boot0 = false;
+	if (argc > 1 && std::strcmp(argv[1], "--boot0") == 0) {
+		boot0 = true;
+	}
+
+	Emulator *emulator = new Emulator(boot0);
 	emulator->run();
 	delete emulator;
 


### PR DESCRIPTION
Adds a command line option `--boot0` to run boot0 instead of boot1.
Currently boots until jumping to boot1 which results in an undefined instruction without a valid boot1 key, since boot1 cannot be decrypted.