### PR TITLE
Remove boot1 loading in favor of boot0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Wii U Firmware Emulator
-This emulator emulates the Wii U processors and hardware at the lowest level. It's currently able to emulate all the way through boot1, IOSU and Cafe OS up to the Wii U menu.
+This emulator emulates the Wii U processors and hardware at the lowest level. It's currently able to emulate all the way through boot0, boot1, IOSU and Cafe OS up to the Wii U menu.
 
 This emulator used to be written in both Python and C++. You can still find the source code of this emulator in the branch 'old'.
 
 ## Instructions
 1. Make sure you have a linux system, a g++ compiler that supports c++14 and the OpenSSL library.
-2. Dump the following files from your Wii U (with hexFW for example) and put them into the 'files' folder: `boot1.bin`, `otp.bin`, `seeprom.bin`, `mlc.bin`, `slc.bin` and `slccmpt.bin`. This emulator may write to some of these files. Use a backup if you want to keep your original dumps.
-3. Create `files/espresso_key.bin` and put the espresso ancast key into it.
-4. Run `make` to compile the emulator
+2. Dump the following files from your Wii U (with the Wii U NAND Dumper and minute for example) and put them into the 'files' folder: `boot0.bin`, `otp.bin`, `seeprom.bin`, `mlc.bin`, `slc.bin` and `slccmpt.bin`. This emulator may write to some of these files. Use a backup if you want to keep your original dumps.
+3. Edit `files/otp.bin` and insert the boot1 ancast key at offset `0x3A0`.
+4. Create `files/espresso_key.bin` and put the espresso ancast key into it.
+5. Run `make` to compile the emulator.
 
 ## Configuration
 `src/config.h` contains a few macros that enable/disable certain features of the emulator, such as breakpoints. Enabling a feature adds interesting commands to the debugger but may slow down the emulator a bit.

--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -19,7 +19,7 @@ void signal_handler(int signal) {
 }
 
 
-Emulator::Emulator(bool boot0) :
+Emulator::Emulator() :
 	physmem(&hardware),
 	hardware(this),
 	debugger(this),
@@ -29,20 +29,17 @@ Emulator::Emulator(bool boot0) :
 		{this, &reservation, 1},
 		{this, &reservation, 2}
 	},
-	dsp(this),
-	boot0(boot0)
+	dsp(this)
 {
 	reset();
 }
 
 void Emulator::reset() {
-
-	Buffer buffer = FileUtils::load(boot0 ? "files/boot0.bin" : "files/boot1.bin");
-	uint32_t load_address = boot0 ? 0xFFFF0000 : 0xD400200;
-	physmem.write(load_address, buffer);
+	Buffer buffer = FileUtils::load("files/boot0.bin");
+	physmem.write(0xFFFF0000, buffer);
 
 	arm.reset();
-	arm.core.regs[ARMCore::PC] = load_address;
+	arm.core.regs[ARMCore::PC] = 0xFFFF0000;
 	arm.enable();
 	
 	reservation.reset();

--- a/src/emulator.h
+++ b/src/emulator.h
@@ -14,7 +14,7 @@
 
 class Emulator {
 public:
-	Emulator(bool boot0);
+	Emulator();
 	
 	void run();
 	void pause();
@@ -36,5 +36,4 @@ private:
 	int core;
 	
 	bool running;
-	bool boot0;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,12 +7,7 @@ int main(int argc, const char *argv[]) {
 	Logger::init(Logger::DEBUG);
 	History::init();
 
-	bool boot0 = false;
-	if (argc > 1 && std::strcmp(argv[1], "--boot0") == 0) {
-		boot0 = true;
-	}
-
-	Emulator *emulator = new Emulator(boot0);
+	Emulator *emulator = new Emulator();
 	emulator->run();
 	delete emulator;
 


### PR DESCRIPTION
With the release of [de_Fuse](https://douevenknow.us/post/714056575412764672/defuse-the-one-true-pwn) we finally have access to the boot1 ancast key, by bruteforcing the key using 15 zero-encrypted boot1 parts, each with one more part of the key present.
I modified the script linked in the article to read boot1 directly from the `slc.bin`: <https://gist.github.com/GaryOderNichts/ea146401ba68db756b238a6344dffe0b>
By inserting the boot1 key into the OTP and using a build since #16, this allows booting from boot0 all the way up to the Wii U menu.
Boot0 can be dumped with [minute](https://github.com/GaryOderNichts/minute/tree/romdumper) (updated fork which builds on latest devkitARM) for example.

This PR removes boot1 loading in favor of direct boot0 loading (which will load and decrypt boot1 from the SLC). If you want to keep boot1 support, feel free to close the PR.