### PR TITLE
Fix compiling with GCC13

### DIFF
--- a/src/common/stringutils.h
+++ b/src/common/stringutils.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <ciso646>
 #include <cstdio>
+#include <cstdint>
 #include <stdexcept>
 #include <type_traits>
 #include <sstream>


### PR DESCRIPTION
`stringutils.h` uses `uint64_t` in `format_number`.
Since GCC13, `cstdint` is less widely used internally and needs to be included explicitly.